### PR TITLE
Install missing dependency xapian-core

### DIFF
--- a/Dockerfile-archlinux
+++ b/Dockerfile-archlinux
@@ -101,7 +101,8 @@ RUN pacman --noconfirm -Sy \
                                 automoc4 \
                                 qt5-multimedia \
                                 qt5-gstreamer \
-                                eigen
+                                eigen \
+                                xapian-core
 # PIM
 RUN pacman --noconfirm -Sy \
                                 libdmtx qrencode \


### PR DESCRIPTION
khelpcenter depends on xapian-core but this dependency was not
installed, causing the build to fail.
