### PR TITLE
archlinux: fix qca by building against openssl-1.0

### DIFF
--- a/Dockerfile-archlinux
+++ b/Dockerfile-archlinux
@@ -21,6 +21,7 @@ MAINTAINER Mathieu Tarral <mathieu.tarral@gmail.com>
 # kservice              |       flex bison
 # gpgme                 |       autoconf automake
 # kirigami              |       qt5-quickcontrols2
+# qca                   |       openssl-1.0
 #---------------------------------------------------------
 # WORKSPACE             |       BUILD DEPENDENCY
 #-----------------------|---------------------------------
@@ -82,7 +83,8 @@ RUN pacman --noconfirm -Sy \
                                 gperf \
                                 flex bison \
                                 autoconf automake \
-                                qt5-quickcontrols2
+                                qt5-quickcontrols2 \
+                                openssl-1.0
 # Workspace
 RUN pacman --noconfirm -Sy \
                                 libpwquality \

--- a/kdesrc-buildrc
+++ b/kdesrc-buildrc
@@ -19,6 +19,14 @@ global
     stop-on-failure true
 end global
 
+options kdelibs4support
+    cmake-options -DOPENSSL_INCLUDE_DIR=/usr/include/openssl-1.0
+end options
+
+options qca
+    cmake-options -DOPENSSL_INCLUDE_DIR=/usr/include/openssl-1.0
+end options
+
 # Instead of specifying modules here, the current best practice is to refer to
 # KF5 module lists maintained with kdesrc-build by the KF5 developers. As new
 # modules are added or modified, the kdesrc-build KF5 module list is altered to


### PR DESCRIPTION
cc @hillmarcus, it worked.