### PR TITLE
Add install of archlinux-keyring package before system upgrade 

### DIFF
--- a/Dockerfile-archlinux
+++ b/Dockerfile-archlinux
@@ -56,6 +56,11 @@ MAINTAINER Mathieu Tarral <mathieu.tarral@gmail.com>
 # kcalcore              |       libical
 #-----------------------|---------------------------------
 
+# Update keyring
+#---------------------------
+RUN pacman --noconfirm -Sy
+RUN pacman --noconfirm -Sy archlinux-keyring
+
 # General upgrade
 #---------------------------
 RUN pacman --noconfirm -Syu


### PR DESCRIPTION
The first `pacman --noconfirm -Syu` command to run the system upgrade gives me an error about missing PGP keys.  This PR adds a `pacman --noconfirm -Sy archlinux-keyring` command before the system upgrade to first fetch the necessary signing keys.  

After making this change, running `docker build -t archlinux-kdedev -f Dockerfile-archlinux .` runs successfully.