### PR TITLE
Add libnm to archlinux Dockerfile for networkmanager-qt

### DIFF
--- a/Dockerfile-archlinux
+++ b/Dockerfile-archlinux
@@ -85,7 +85,7 @@ RUN pacman --noconfirm -Sy \
                                 vlc \
                                 pkg-config \
                                 libnm-glib \
-				libnm \
+                                libnm \
                                 qca-qt5 \
                                 qt5-webkit \
                                 gperf \

--- a/Dockerfile-archlinux
+++ b/Dockerfile-archlinux
@@ -13,7 +13,7 @@ MAINTAINER Mathieu Tarral <mathieu.tarral@gmail.com>
 # khtml                 |       giflib
 # phonon-vlc            |       vlc
 # phonon-gstreamer      |       pkg-config
-# networkmanager-qt     |       libnm-glib
+# networkmanager-qt     |       libnm-glib libnm
 # plasma-nm             |       qca-qt5
 # baloo                 |       lmdb
 # kdewebkit             |       qt5-webkit
@@ -85,6 +85,7 @@ RUN pacman --noconfirm -Sy \
                                 vlc \
                                 pkg-config \
                                 libnm-glib \
+				libnm \
                                 qca-qt5 \
                                 qt5-webkit \
                                 gperf \


### PR DESCRIPTION
The networkmanager-qt package fails to build without the "libnm" package from pacman.  This PR adds that dependency to Dockerfile-archlinux.